### PR TITLE
[BTFS-869] - converting readmes from ipfs to btfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <h1 align="center">
-  <a href="https://ipfs.io"><img width="650px" src="https://ipfs.io/ipfs/QmQJ68PFMDdAsgCZvA1UVzzn18asVcf7HVvCDgpjiSCAse" alt="IPFS http client lib logo" /></a>
+  <a href="https://ipfs.io"><img width="650px" src="https://ipfs.io/ipfs/QmQJ68PFMDdAsgCZvA1UVzzn18asVcf7HVvCDgpjiSCAse" alt="BTFS http client lib logo" /></a>
 </h1>
 
-<h3 align="center">The JavaScript HTTP client library for IPFS implementations.</h3>
+<h3 align="center">The JavaScript HTTP client library for BTFS implementations.</h3>
 
 <p align="center">
   <a href="http://ipn.io"><img src="https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square" /></a>
@@ -26,7 +26,7 @@
   <br>
 </p>
 
-> A client library for the IPFS HTTP API, implemented in JavaScript. This client library implements the [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core) enabling applications to change between an embedded js-ipfs node and any remote IPFS node without having to change the code. In addition, this client library implements a set of utility functions.
+> A client library for the BTFS HTTP API, implemented in JavaScript. This client library implements the [interface-ipfs-core](https://github.com/TRON-US/js-btfs-http-client) enabling applications to change between an embedded js-btfs node and any remote BTFS node without having to change the code. In addition, this client library implements a set of utility functions.
 
 ## Lead Maintainer
 
@@ -74,15 +74,15 @@ We support both the Current and Active LTS versions of Node.js. Please see [node
 To interact with the API, you need to have a local daemon running. It needs to be open on the right port. `5001` is the default, and is used in the examples below, but it can be set to whatever you need.
 
 ```sh
-# Show the ipfs config API port to check it is correct
-> ipfs config Addresses.API
+# Show the btfs config API port to check it is correct
+> btfs config Addresses.API
 /ip4/127.0.0.1/tcp/5001
 # Set it if it does not match the above output
-> ipfs config Addresses.API /ip4/127.0.0.1/tcp/5001
+> btfs config Addresses.API /ip4/127.0.0.1/tcp/5001
 # Restart the daemon after changing the config
 
 # Run the daemon
-> ipfs daemon
+> btfs daemon
 ```
 
 ### Importing the module and usage
@@ -126,7 +126,7 @@ See the example in the [examples folder](/examples/bundle-webpack) to get an ide
 
 **from CDN**
 
-Instead of a local installation (and browserification) you may request a remote copy of IPFS API from [unpkg CDN](https://unpkg.com/).
+Instead of a local installation (and browserification) you may request a remote copy of BTFS API from [unpkg CDN](https://unpkg.com/).
 
 To always request the latest version, use the following:
 
@@ -138,19 +138,19 @@ Note: remove the `.min` from the URL to get the human-readable (not minified) ve
 
 For maximum security you may also decide to:
 
-* reference a specific version of IPFS API (to prevent unexpected breaking changes when a newer latest version is published)
+* reference a specific version of BTFS API (to prevent unexpected breaking changes when a newer latest version is published)
 * [generate a SRI hash](https://www.srihash.org/) of that version and use it to ensure integrity
 * set the [CORS settings attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) to make anonymous requests to CDN
 
 Example:
 
 ```html
-<script src="https://unpkg.com/ipfs-http-client@9.0.0/dist/index.js"
+<script src="https://unpkg.com/btfs-http-client@9.0.0/dist/index.js"
 integrity="sha384-5bXRcW9kyxxnSMbOoHzraqa7Z0PQWIao+cgeg327zit1hz5LZCEbIMx/LWKPReuB"
 crossorigin="anonymous"></script>
 ```
 
-CDN-based IPFS API provides the `IpfsHttpClient` constructor as a method of the global `window` object. Example:
+CDN-based BTFS API provides the `IpfsHttpClient` constructor as a method of the global `window` object. Example:
 
 ```js
 const ipfs = window.IpfsHttpClient({ host: 'localhost', port: 5001 })
@@ -164,7 +164,7 @@ const ipfs = window.IpfsHttpClient()
 
 ### CORS
 
-In a web browser IPFS HTTP client (either browserified or CDN-based) might encounter an error saying that the origin is not allowed. This would be a CORS ("Cross Origin Resource Sharing") failure: IPFS servers are designed to reject requests from unknown domains by default. You can whitelist the domain that you are calling from by changing your ipfs config like this:
+In a web browser BTFS HTTP client (either browserified or CDN-based) might encounter an error saying that the origin is not allowed. This would be a CORS ("Cross Origin Resource Sharing") failure: BTFS servers are designed to reject requests from unknown domains by default. You can whitelist the domain that you are calling from by changing your ipfs config like this:
 
 ```console
 $ ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin  '["http://example.com"]'
@@ -202,9 +202,9 @@ const ipfs = ipfsClient({ timeout: '2m' })
 
 ### API
 
-[![IPFS Core API Compatible](https://cdn.rawgit.com/ipfs/interface-ipfs-core/master/img/badge.svg)](https://github.com/ipfs/interface-ipfs-core)
+[![BTFS Core API Compatible](https://cdn.rawgit.com/ipfs/interface-ipfs-core/master/img/badge.svg)](https://github.com/ipfs/interface-ipfs-core)
 
-> `js-ipfs-http-client` follows the spec defined by [`interface-ipfs-core`](https://github.com/ipfs/interface-ipfs-core), which concerns the interface to expect from IPFS implementations. This interface is a currently active endeavor. You can use it today to consult the methods available.
+> `js-btfs-http-client` follows the spec defined by [`interface-ipfs-core`](https://github.com/TRON-US/js-btfs-http-client), which concerns the interface to expect from BTFS implementations. This interface is a currently active endeavor. You can use it today to consult the methods available.
 
 #### Files
 
@@ -408,20 +408,20 @@ We run tests by executing `npm test` in a terminal window. This will run both No
 
 ## Contribute
 
-The js-ipfs-http-client is a work in progress. As such, there's a few things you can do right now to help out:
+The js-btfs-http-client is a work in progress. As such, there's a few things you can do right now to help out:
 
 - **[Check out the existing issues](https://github.com/ipfs/js-ipfs-http-client/issues)**!
 - **Perform code reviews**. More eyes will help a) speed the project along b) ensure quality and c) reduce possible future bugs.
 - **Add tests**. There can never be enough tests. Note that interface tests exist inside [`interface-ipfs-core`](https://github.com/ipfs/interface-ipfs-core/tree/master/js/src).
-- **Contribute to the [FAQ repository](https://github.com/ipfs/faq/issues)** with any questions you have about IPFS or any of the relevant technology. A good example would be asking, 'What is a merkledag tree?'. If you don't know a term, odds are, someone else doesn't either. Eventually, we should have a good understanding of where we need to improve communications and teaching together to make IPFS and IPN better.
+- **Contribute to the [FAQ repository](https://github.com/ipfs/faq/issues)** with any questions you have about BTFS or any of the relevant technology. A good example would be asking, 'What is a merkledag tree?'. If you don't know a term, odds are, someone else doesn't either. Eventually, we should have a good understanding of where we need to improve communications and teaching together to make BTFS and IPN better.
 
-**Want to hack on IPFS?**
+**Want to hack on BTFS?**
 
 [![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md)
 
 ## Historical context
 
-This module started as a direct mapping from the go-ipfs cli to a JavaScript implementation, although this was useful and familiar to a lot of developers that were coming to IPFS for the first time, it also created some confusion on how to operate the core of IPFS and have access to the full capacity of the protocol. After much consideration, we decided to create `interface-ipfs-core` with the goal of standardizing the interface of a core implementation of IPFS, and keep the utility functions the IPFS community learned to use and love, such as reading files from disk and storing them directly to IPFS.
+This module started as a direct mapping from the go-btfs cli to a JavaScript implementation, although this was useful and familiar to a lot of developers that were coming to BTFS for the first time, it also created some confusion on how to operate the core of BTFS and have access to the full capacity of the protocol. After much consideration, we decided to create `interface-ipfs-core` with the goal of standardizing the interface of a core implementation of BTFS, and keep the utility functions the BTFS community learned to use and love, such as reading files from disk and storing them directly to BTFS.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -3,22 +3,9 @@
 </h1>
 
 <h3 align="center">The JavaScript HTTP client library for BTFS implementations.</h3>
-
-<p align="center">
-  <a href="http://ipn.io"><img src="https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square" /></a>
-  <a href="http://ipfs.io/"><img src="https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square" /></a>
-  <a href="http://webchat.freenode.net/?channels=%23ipfs"><img src="https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square" /></a>
-  <a href="https://waffle.io/ipfs/js-ipfs"><img src="https://img.shields.io/badge/pm-waffle-blue.svg?style=flat-square" /></a>
-  <a href="https://github.com/ipfs/interface-ipfs-core"><img src="https://img.shields.io/badge/interface--ipfs--core-API%20Docs-blue.svg?style=flat-square"></a>
-</p>
-
 <p align="center">
   <a href="https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fipfs%2Fjs-ipfs-http-client?ref=badge_small" alt="FOSSA Status"><img src="https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fipfs%2Fjs-ipfs-http-client.svg?type=small"/></a>
-  <a href="https://travis-ci.com/ipfs/js-ipfs-http-client"><img src="https://flat.badgen.net/travis/ipfs/js-ipfs-http-client" /></a>
-  <a href="https://codecov.io/gh/ipfs/js-ipfs-http-client"><img src="https://img.shields.io/codecov/c/github/ipfs/js-ipfs-http-client/master.svg?style=flat-square"></a>
-   <a href="https://bundlephobia.com/result?p=ipfs-http-client"><img src="https://flat.badgen.net/bundlephobia/minzip/ipfs-http-client"></a>
   <br>
-  <a href="https://david-dm.org/ipfs/js-ipfs-http-client"><img src="https://david-dm.org/ipfs/js-ipfs-http-client.svg?style=flat-square" /></a>
   <a href="https://github.com/feross/standard"><img src="https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square"></a>
   <a href="https://github.com/RichardLitt/standard-readme"><img src="https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square" /></a>
   <a href=""><img src="https://img.shields.io/badge/npm-%3E%3D3.0.0-orange.svg?style=flat-square" /></a>
@@ -28,13 +15,8 @@
 
 > A client library for the BTFS HTTP API, implemented in JavaScript. This client library implements the [interface-ipfs-core](https://github.com/TRON-US/js-btfs-http-client) enabling applications to change between an embedded js-ipfs node and any remote BTFS node without having to change the code. In addition, this client library implements a set of utility functions.
 
-## Lead Maintainer
-
-[Alan Shaw](http://github.com/alanshaw).
-
 ## Table of Contents
 
-- [Lead Maintainer](#lead-maintainer)
 - [Table of Contents](#table-of-contents)
 - [Install](#install)
   - [Running the daemon with the right port](#running-the-daemon-with-the-right-port)
@@ -201,8 +183,6 @@ const ipfs = ipfsClient({ timeout: '2m' })
 ## Usage
 
 ### API
-
-[![BTFS Core API Compatible](https://cdn.rawgit.com/ipfs/interface-ipfs-core/master/img/badge.svg)](https://github.com/ipfs/interface-ipfs-core)
 
 > `js-btfs-http-client` follows the spec defined by [`interface-ipfs-core`](https://github.com/ipfs/interface-js-ipfs-core), which concerns the interface to expect from BTFS implementations. This interface is a currently active endeavor. You can use it today to consult the methods available.
 
@@ -414,14 +394,6 @@ The js-btfs-http-client is a work in progress. As such, there's a few things you
 - **Perform code reviews**. More eyes will help a) speed the project along b) ensure quality and c) reduce possible future bugs.
 - **Add tests**. There can never be enough tests. Note that interface tests exist inside [`interface-ipfs-core`](https://github.com/ipfs/interface-ipfs-core/tree/master/js/src).
 - **Contribute to the [FAQ repository](https://github.com/ipfs/faq/issues)** with any questions you have about BTFS or any of the relevant technology. A good example would be asking, 'What is a merkledag tree?'. If you don't know a term, odds are, someone else doesn't either. Eventually, we should have a good understanding of where we need to improve communications and teaching together to make BTFS and IPN better.
-
-**Want to hack on BTFS?**
-
-[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md)
-
-## Historical context
-
-This module started as a direct mapping from the go-btfs cli to a JavaScript implementation, although this was useful and familiar to a lot of developers that were coming to BTFS for the first time, it also created some confusion on how to operate the core of BTFS and have access to the full capacity of the protocol. After much consideration, we decided to create `interface-ipfs-core` with the goal of standardizing the interface of a core implementation of BTFS, and keep the utility functions the BTFS community learned to use and love, such as reading files from disk and storing them directly to BTFS.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   <br>
 </p>
 
-> A client library for the BTFS HTTP API, implemented in JavaScript. This client library implements the [interface-ipfs-core](https://github.com/TRON-US/js-btfs-http-client) enabling applications to change between an embedded js-btfs node and any remote BTFS node without having to change the code. In addition, this client library implements a set of utility functions.
+> A client library for the BTFS HTTP API, implemented in JavaScript. This client library implements the [interface-ipfs-core](https://github.com/TRON-US/js-btfs-http-client) enabling applications to change between an embedded js-ipfs node and any remote BTFS node without having to change the code. In addition, this client library implements a set of utility functions.
 
 ## Lead Maintainer
 
@@ -204,7 +204,7 @@ const ipfs = ipfsClient({ timeout: '2m' })
 
 [![BTFS Core API Compatible](https://cdn.rawgit.com/ipfs/interface-ipfs-core/master/img/badge.svg)](https://github.com/ipfs/interface-ipfs-core)
 
-> `js-btfs-http-client` follows the spec defined by [`interface-ipfs-core`](https://github.com/TRON-US/js-btfs-http-client), which concerns the interface to expect from BTFS implementations. This interface is a currently active endeavor. You can use it today to consult the methods available.
+> `js-btfs-http-client` follows the spec defined by [`interface-ipfs-core`](https://github.com/ipfs/interface-js-ipfs-core), which concerns the interface to expect from BTFS implementations. This interface is a currently active endeavor. You can use it today to consult the methods available.
 
 #### Files
 
@@ -380,7 +380,7 @@ Call this on your client instance to return an object containing the `host`, `po
 
 #### Static Types and Utils
 
-Aside from the default export, `ipfs-http-client` exports various types and utilities that are included in the bundle:
+Aside from the default export, `btfs-http-client` exports various types and utilities that are included in the bundle:
 
 - [`isIPFS`](https://www.npmjs.com/package/is-ipfs)
 - [`Buffer`](https://www.npmjs.com/package/buffer)
@@ -410,7 +410,7 @@ We run tests by executing `npm test` in a terminal window. This will run both No
 
 The js-btfs-http-client is a work in progress. As such, there's a few things you can do right now to help out:
 
-- **[Check out the existing issues](https://github.com/ipfs/js-ipfs-http-client/issues)**!
+- **[Check out the existing issues](https://github.com/ipfs/js-btfs-http-client/issues)**!
 - **Perform code reviews**. More eyes will help a) speed the project along b) ensure quality and c) reduce possible future bugs.
 - **Add tests**. There can never be enough tests. Note that interface tests exist inside [`interface-ipfs-core`](https://github.com/ipfs/interface-ipfs-core/tree/master/js/src).
 - **Contribute to the [FAQ repository](https://github.com/ipfs/faq/issues)** with any questions you have about BTFS or any of the relevant technology. A good example would be asking, 'What is a merkledag tree?'. If you don't know a term, odds are, someone else doesn't either. Eventually, we should have a good understanding of where we need to improve communications and teaching together to make BTFS and IPN better.

--- a/examples/browser-pubsub/README.md
+++ b/examples/browser-pubsub/README.md
@@ -2,7 +2,7 @@
 
 > Use pubsub in the browser!
 
-This example is a demo web application that allows you to connect to an IPFS node, subscribe to a pubsub topic and send/receive messages. We'll start two IPFS nodes and two browsers and use the `ipfs-http-client` to instruct each node to listen to a pubsub topic and send/receive pubsub messages to/from each other. We're aiming for something like this:
+This example is a demo web application that allows you to connect to an BTFS node, subscribe to a pubsub topic and send/receive messages. We'll start two IPFS nodes and two browsers and use the `ipfs-http-client` to instruct each node to listen to a pubsub topic and send/receive pubsub messages to/from each other. We're aiming for something like this:
 
 ```
    +-----------+                   +-----------+
@@ -29,9 +29,9 @@ This example is a demo web application that allows you to connect to an IPFS nod
 With Node.js and git installed, clone the repo and install the project dependencies:
 
 ```sh
-git clone https://github.com/ipfs/js-ipfs-http-client.git
-cd js-ipfs-http-client
-npm install # Installs ipfs-http-client dependencies
+git clone https://github.com/TRON-US/js-btfs-http-client
+cd js-btfs-http-client
+npm install # Installs btfs-http-client dependencies
 cd examples/browser-pubsub
 npm install # Installs browser-pubsub app dependencies
 ```
@@ -50,11 +50,11 @@ Available on:
   http://127.0.0.1:8888
 ```
 
-## 2. Start two IPFS nodes
+## 2. Start two BTFS nodes
 
 To demonstrate pubsub we need two nodes running so pubsub messages can be passed between them.
 
-Right now the easiest way to do this is to install and start a `js-ipfs` and `go-ipfs` node. There are other ways to do this, see [this document on running multiple nodes](https://github.com/ipfs/js-ipfs/tree/master/examples/running-multiple-nodes) for details.
+Right now the easiest way to do this is to install and start a `js-ipfs` and `go-btfs` node. There are other ways to do this, see [this document on running multiple nodes](https://github.com/ipfs/js-ipfs/tree/master/examples/running-multiple-nodes) for details.
 
 ### Install and start the JS IPFS node
 
@@ -67,18 +67,18 @@ jsipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["http://127.0
 jsipfs daemon --enable-pubsub-experiment
 ```
 
-### Install and start the Go IPFS node
+### Install and start the Go BTFS node
 
-Head over to https://dist.ipfs.io/#go-ipfs and hit the "Download go-ipfs" button. Extract the archive and read the instructions to install.
+Head over to https://dist.ipfs.io/#go-ipfs and hit the "Download go-btfs" button. Extract the archive and read the instructions to install.
 
 After installation:
 
 ```sh
-ipfs init
-# Configure CORS to allow ipfs-http-client to access this IPFS node
-ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["http://127.0.0.1:8888"]'
-# Start the IPFS node, enabling pubsub
-ipfs daemon --enable-pubsub-experiment
+btfs init
+# Configure CORS to allow btfs-http-client to access this BTFS node
+btfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["http://127.0.0.1:8888"]'
+# Start the BTFS node, enabling pubsub
+btfs daemon --enable-pubsub-experiment
 ```
 
 ## 3. Open two browsers and connect to each node
@@ -87,8 +87,8 @@ Now, open up **two** browser windows. This could be two tabs in the same browser
 
 In the "API ADDR" field enter `/ip4/127.0.0.1/tcp/5001` in one browser and `/ip4/127.0.0.1/tcp/5002` in the other and hit the "Connect" button.
 
-This connects each browser to an IPFS node and now from the comfort of our browser we can instruct each node to listen to a pubsub topic and send/receive pubsub messages to each other.
+This connects each browser to a BTFS node and now from the comfort of our browser we can instruct each node to listen to a pubsub topic and send/receive pubsub messages to each other.
 
-> N.B. Since our two IPFS nodes are running on the same network they should have already found each other by MDNS. So you probably won't need to use the "CONNECT TO PEER" field. If you find your pubsub messages aren't getting through, check the output from your `jsipfs daemon` command and find the first address listed in "Swarm listening on" - it'll look like `/ip4/127.0.0.1/tcp/4002/ipfs/Qm...`. Paste this address into the "CONNECT TO PEER" field for the browser that is connected to your go-ipfs node and hit connect.
+> N.B. Sibnce our two BTFS nodes are running on the same network they should have already found each other y MDNS. So you probably won't need to use the "CONNECT TO PEER" field. If you find your pubsub messages aren't getting through, check the output from your `jsipfs daemon` command and find the first address listed in "Swarm listening on" - it'll look like `/ip4/127.0.0.1/tcp/4002/ipfs/Qm...`. Paste this address into the "CONNECT TO PEER" field for the browser that is connected to your go-btfs node and hit connect.
 
 Finally, use the "SUBSCRIBE TO PUBSUB TOPIC" and "SEND MESSAGE" fields to do some pubsub-ing, you should see messages sent from one browser appear in the log of the other (provided they're both subscribed to the same topic).

--- a/examples/browser-pubsub/README.md
+++ b/examples/browser-pubsub/README.md
@@ -2,12 +2,12 @@
 
 > Use pubsub in the browser!
 
-This example is a demo web application that allows you to connect to an BTFS node, subscribe to a pubsub topic and send/receive messages. We'll start two IPFS nodes and two browsers and use the `ipfs-http-client` to instruct each node to listen to a pubsub topic and send/receive pubsub messages to/from each other. We're aiming for something like this:
+This example is a demo web application that allows you to connect to an BTFS node, subscribe to a pubsub topic and send/receive messages. We'll start two BTFS nodes and two browsers and use the `btfs-http-client` to instruct each node to listen to a pubsub topic and send/receive pubsub messages to/from each other. We're aiming for something like this:
 
 ```
    +-----------+                   +-----------+
    |           +------------------->           |
-   |  js-ipfs  |      pubsub       |  go-ipfs  |
+   |  js-ipfs  |      pubsub       |  go-btfs  |
    |           <-------------------+           |
    +-----^-----+                   +-----^-----+
          |                               |
@@ -69,7 +69,7 @@ jsipfs daemon --enable-pubsub-experiment
 
 ### Install and start the Go BTFS node
 
-Head over to https://dist.ipfs.io/#go-ipfs and hit the "Download go-btfs" button. Extract the archive and read the instructions to install.
+Head over to https://github.com/TRON-US/btfs-binary-releases and read the instructions to install.
 
 After installation:
 
@@ -89,6 +89,6 @@ In the "API ADDR" field enter `/ip4/127.0.0.1/tcp/5001` in one browser and `/ip4
 
 This connects each browser to a BTFS node and now from the comfort of our browser we can instruct each node to listen to a pubsub topic and send/receive pubsub messages to each other.
 
-> N.B. Sibnce our two BTFS nodes are running on the same network they should have already found each other y MDNS. So you probably won't need to use the "CONNECT TO PEER" field. If you find your pubsub messages aren't getting through, check the output from your `jsipfs daemon` command and find the first address listed in "Swarm listening on" - it'll look like `/ip4/127.0.0.1/tcp/4002/ipfs/Qm...`. Paste this address into the "CONNECT TO PEER" field for the browser that is connected to your go-btfs node and hit connect.
+> N.B. Since our two BTFS nodes are running on the same network they should have already found each other y MDNS. So you probably won't need to use the "CONNECT TO PEER" field. If you find your pubsub messages aren't getting through, check the output from your `jsipfs daemon` command and find the first address listed in "Swarm listening on" - it'll look like `/ip4/127.0.0.1/tcp/4002/ipfs/Qm...`. Paste this address into the "CONNECT TO PEER" field for the browser that is connected to your go-btfs node and hit connect.
 
 Finally, use the "SUBSCRIBE TO PUBSUB TOPIC" and "SEND MESSAGE" fields to do some pubsub-ing, you should see messages sent from one browser appear in the log of the other (provided they're both subscribed to the same topic).

--- a/examples/bundle-browserify/README.md
+++ b/examples/bundle-browserify/README.md
@@ -1,12 +1,12 @@
-# Bundle js-ipfs-http-client with Browserify!
+# Bundle js-btfs-http-client with Browserify!
 
-> In this example, you will find a boilerplate you can use to guide yourself into bundling js-ipfs-http-client with browserify, so that you can use it in your own web app!
+> In this example, you will find a boilerplate you can use to guide yourself into bundling js-btfs-http-client with browserify, so that you can use it in your own web app!
 
 ## Setup
 
-As for any js-ipfs-http-client example, **you need a running IPFS daemon**, you learn how to do that here:
+As for any js-btfs-http-client example, **you need a running BTFS daemon**, you learn how to do that here:
 
-- [Spawn a go-ipfs daemon](https://ipfs.io/docs/getting-started/)
+- [Spawn a go-btfs daemon](https://ipfs.io/docs/getting-started/)
 - [Spawn a js-ipfs daemon](https://github.com/ipfs/js-ipfs#usage)
 
 **Note:** If you load your app from a different domain than the one the daemon is running (most probably), you will need to set up CORS, see https://github.com/ipfs/js-ipfs-http-client#cors to learn how to do that.
@@ -14,8 +14,8 @@ As for any js-ipfs-http-client example, **you need a running IPFS daemon**, you 
 A quick (and dirty way to get it done) is:
 
 ```bash
-> ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin "[\"*\"]"
-> ipfs config --json API.HTTPHeaders.Access-Control-Allow-Credentials "[\"true\"]"
+> btfs config --json API.HTTPHeaders.Access-Control-Allow-Origin "[\"*\"]"
+> btfs config --json API.HTTPHeaders.Access-Control-Allow-Credentials "[\"true\"]"
 ```
 
 ## Run this example

--- a/examples/bundle-browserify/README.md
+++ b/examples/bundle-browserify/README.md
@@ -9,7 +9,7 @@ As for any js-btfs-http-client example, **you need a running BTFS daemon**, you 
 - [Spawn a go-btfs daemon](https://ipfs.io/docs/getting-started/)
 - [Spawn a js-ipfs daemon](https://github.com/ipfs/js-ipfs#usage)
 
-**Note:** If you load your app from a different domain than the one the daemon is running (most probably), you will need to set up CORS, see https://github.com/ipfs/js-ipfs-http-client#cors to learn how to do that.
+**Note:** If you load your app from a different domain than the one the daemon is running (most probably), you will need to set up CORS, see https://github.com/TRON-US/js-btfs-http-client#cors to learn how to do that.
 
 A quick (and dirty way to get it done) is:
 

--- a/examples/bundle-webpack/README.md
+++ b/examples/bundle-webpack/README.md
@@ -1,15 +1,15 @@
 # Bundle js-ipfs-http-client with Webpack!
 
-> In this example, you will find a boilerplate you can use to guide yourself into bundling js-ipfs-http-client with webpack, so that you can use it in your own web app!
+> In this example, you will find a boilerplate you can use to guide yourself into bundling js-btfs-http-client with webpack, so that you can use it in your own web app!
 
 ## Setup
 
-As for any js-ipfs-http-client example, **you need a running IPFS daemon**, you learn how to do that here:
+As for any js-btfs-http-client example, **you need a running IPFS daemon**, you learn how to do that here:
 
-- [Spawn a go-ipfs daemon](https://ipfs.io/docs/getting-started/)
+- [Spawn a go-btfs daemon](https://ipfs.io/docs/getting-started/)
 - [Spawn a js-ipfs daemon](https://github.com/ipfs/js-ipfs#usage)
 
-**Note:** If you load your app from a different domain than the one the daemon is running (most probably), you will need to set up CORS, see https://github.com/ipfs/js-ipfs-http-client#cors to learn how to do that.
+**Note:** If you load your app from a different domain than the one the daemon is running (most probably), you will need to set up CORS, see https://github.com/TRON-US/js-btfs-http-client#cors#cors to learn how to do that.
 
 A quick (and dirty way to get it done) is:
 

--- a/examples/name-api/README.md
+++ b/examples/name-api/README.md
@@ -2,12 +2,12 @@
 
 ## Setup
 
-Install [go-ipfs](https://ipfs.io/docs/install/) and start the daemon.
+Install [go-btfs](https://github.com/TRON-US/go-btfs) and start the daemon.
 
-Configure CORS as suggested by the README https://github.com/ipfs/js-ipfs-http-client#cors
+Configure CORS as suggested by the README https://github.com/TRON-US/js-btfs-http-client#cors
 
 ```bash
-> ipfs daemon
+> btfs daemon
 ```
 
 then in this folder run

--- a/examples/upload-file-via-browser/README.md
+++ b/examples/upload-file-via-browser/README.md
@@ -1,12 +1,12 @@
-# Upload file to IPFS via browser using js-ipfs-http-client
+# Upload file to BTFS via browser using js-btfs-http-client
 
-> In this example, you will find a simple React app to upload a file to IPFS via the browser using js-ipfs-http-client and Webpack.
+> In this example, you will find a simple React app to upload a file to BTFS via the browser using js-btfs-http-client and Webpack.
 
 ## Setup
 
-As for any js-ipfs-http-client example, **you need a running IPFS daemon**, you learn how to do that here:
+As for any js-btfs-http-client example, **you need a running BTFS daemon**, you learn how to do that here:
 
-- [Spawn a go-ipfs daemon](https://ipfs.io/docs/getting-started/)
+- [Spawn a go-btfs daemon](https://ipfs.io/docs/getting-started/)
 - [Spawn a js-ipfs daemon](https://github.com/ipfs/js-ipfs#usage)
 
 **Note:** If you load your app from a different domain than the one the daemon is running (most probably), you will need to set up CORS, see https://github.com/ipfs/js-ipfs-http-client#cors to learn how to do that.
@@ -14,8 +14,8 @@ As for any js-ipfs-http-client example, **you need a running IPFS daemon**, you 
 A quick (and dirty way to get it done) is:
 
 ```bash
-> ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin "[\"*\"]"
-> ipfs config --json API.HTTPHeaders.Access-Control-Allow-Credentials "[\"true\"]"
+> btfs config --json API.HTTPHeaders.Access-Control-Allow-Origin "[\"*\"]"
+> btfs config --json API.HTTPHeaders.Access-Control-Allow-Credentials "[\"true\"]"
 ```
 
 ## Run this example
@@ -31,4 +31,4 @@ Now open your browser at `http://localhost:3000`
 
 After uploading a file (left screen), and opening the uploaded file (right screen), you should see something like:
 
-> ![App Screenshot](https://github.com/ipfs/js-ipfs-http-client/raw/master/examples/upload-file-via-browser/screenshot.png)
+> ![App Screenshot](https://github.com/TRON-US/js-btfs-http-client/raw/master/examples/upload-file-via-browser/screenshot.png)


### PR DESCRIPTION
https://github.com/ipfs/js-ipfs-http-client forked into js-btfs-http-client repo. 

Rename ipfs into btfs. 

Update the related documentation in the repo. 